### PR TITLE
add Keyboard for Xiaomi (Facemoji Lite)

### DIFF
--- a/src/main/resources/apps.yml
+++ b/src/main/resources/apps.yml
@@ -13,6 +13,7 @@ com.bsp.catchlog: CatchLog
 com.facebook.appmanager: Facebook
 com.facebook.services: Facebook
 com.facebook.system: Facebook
+com.facemoji.lite.xiaomi: Keyboard for Xiaomi
 com.google.android.apps.books: Google Play Books
 com.google.android.apps.docs: Google Drive
 com.google.android.apps.googleassistant: Google Assistant


### PR DESCRIPTION
It comes pre-installed on `davinci` (EEA), since the device also comes with Gboard it's fine to disable/uninstall it.