### PR TITLE
Added GPay (India) to list

### DIFF
--- a/src/main/resources/apps.yml
+++ b/src/main/resources/apps.yml
@@ -19,6 +19,7 @@ com.google.android.apps.googleassistant: Google Assistant
 com.google.android.apps.inputmethod.hindi: Google Indic Keyboard
 com.google.android.apps.inputmethod.zhuyin: Google Zhuyin Input
 com.google.android.apps.maps: Google Maps
+com.google.android.apps.nbu.paisa.user: Google Pay (India)
 com.google.android.apps.photos: Google Photos
 com.google.android.apps.subscriptions.red: Google One
 com.google.android.apps.tachyon: Google Duo


### PR DESCRIPTION
Google Pay ([Playstore Link](https://play.google.com/store/apps/details?id=com.google.android.apps.nbu.paisa.user&hl=en_US&gl=US)) is bundled as a default app on new Mi/Redmi phones in India. App is used for UPI Money transfer, shopping etc.
Safe to uninstall using `pm uninstall –k —user 0 app.name` as well.